### PR TITLE
Fixed bug with manually deleting the field making it unresponsive.

### DIFF
--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -170,7 +170,7 @@
       }
       if (typeof newDate === 'string') {
         this._date = this.parseDate(newDate);
-      } else {
+      } else if(newDate) {
         this._date = new Date(newDate);
       }
       this.set();
@@ -686,6 +686,7 @@
           // unset the date when the input is
           // erased
           this.notifyChange();
+          this._unset = true;
         }
       }
       this._resetMaskPos(input);


### PR DESCRIPTION
If you selected a value, then selected the text in the field and hit delete to clear it, you were not able to select new values using the popup menu. This patch fixes that.
