### PR TITLE
Fix language name for rs-latin locale

### DIFF
--- a/src/js/locales/bootstrap-datetimepicker.rs-latin.js
+++ b/src/js/locales/bootstrap-datetimepicker.rs-latin.js
@@ -3,7 +3,7 @@
  * Bojan Milosavlević <milboj@gmail.com>
  */
 ;(function($){
-	$.fn.datetimepicker.dates['rs'] = {
+	$.fn.datetimepicker.dates['rs-latin'] = {
 		days: ["Nedelja","Ponedeljak", "Utorak", "Sreda", "Četvrtak", "Petak", "Subota", "Nedelja"],
 		daysShort: ["Ned", "Pon", "Uto", "Sre", "Čet", "Pet", "Sub", "Ned"],
 		daysMin: ["N", "Po", "U", "Sr", "Č", "Pe", "Su", "N"],


### PR DESCRIPTION
I tried to include rs locale and found out that the language name was the same for both _rs.js_ and _rs-latin.js_ locale scripts.
This commit corrects the language name for rs-latin.js locale script.
