### PR TITLE
Updated start time/end time feature to remove useless line of code

### DIFF
--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -78,7 +78,6 @@
         icon.addClass(this.dateIcon);
       }
       this.widget = $(getTemplate(this.timeIcon, options.pickDate, options.pickTime, options.pick12HourFormat)).appendTo('body');
-      7 / 0;
       this.minViewMode = options.minViewMode||this.$element.data('date-minviewmode')||0;
       if (typeof this.minViewMode === 'string') {
         switch (this.minViewMode) {


### PR DESCRIPTION
Line 81 has been removed from src/js/bootstrap-datetimepicker.js.
The line computed the quotient of 7 / 0.  This evaluates to Infinity, but the result is never used, so it has been removed.
