### PR TITLE
Option to have separate buttons for editing date and time

### DIFF
--- a/test.html
+++ b/test.html
@@ -1,0 +1,39 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <meta name="description" content="Date/Time Picker for Twitter Boostrap"/>
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+  <title>Bootstrap Date/Time Picker</title>
+  <link rel="stylesheet" media="screen" href="http://netdna.bootstrapcdn.com/twitter-bootstrap/2.2.2/css/bootstrap.min.css" >
+  <link rel="stylesheet" type="text/css" media="screen" href="build/css/bootstrap-datetimepicker.min.css">
+  <script type="text/javascript" src="http://cdnjs.cloudflare.com/ajax/libs/jquery/1.8.3/jquery.min.js"></script>
+  <script type="text/javascript" src="http://netdna.bootstrapcdn.com/twitter-bootstrap/2.2.2/js/bootstrap.min.js"></script>
+  <script src="src/js/bootstrap-datetimepicker.js"></script>
+</head>
+<body>
+  <h4 id='similar_to_above_example_but_in_us_datehour_format'>Example of the pickDateAndTimeIndependently option:</h4>
+  <div class='well'>
+    <div class='input-append' id='datetimepicker'>
+      <input data-format='MM/dd/yyyy HH:mm PP' type='text' />
+      <span class='add-on'>
+        <i data-date-icon='icon-calendar'></i>
+      </span>
+      <span class='add-on'>
+        <i data-time-icon='icon-time'></i>
+      </span>
+    </div>
+  </div>
+  <script type='text/javascript'>
+    $(function() {
+      $('#datetimepicker').datetimepicker({
+        language: 'en',
+        pick12HourFormat: true,
+        pickDateAndTimeIndependently: true,
+        pickTime: false,
+        pickSeconds: false
+      });
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
Having the option of the UI separated into independent date and time widgets lets the user modify only which portion they care about. Without this option, to edit just the time you have to click through the date widget, which is an annoying extra click.

This pull request is a more of a feature request with proof of concept really. It's fully functional, but I haven't tested edge cases etc. Perhaps you could adapt these changes to fit into your codebase.

![Screenshot_2_28_13_6_09_PM](https://f.cloud.github.com/assets/113138/208145/8df23c54-8215-11e2-8835-4926d057a8f6.png)

The pickDateAndTimeIndependently option allows you to have separate
calendar and time buttons in the datetimepicker input box.
