### PR TITLE
Fix for extraneous tbody tags with latest jQuery

### DIFF
--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -294,7 +294,10 @@
         } else {
           dateStr = this.$element.find('input').val();
         }
-        if (!dateStr) {
+        if (dateStr) {
+          this._date = this.parseDate(dateStr);
+        }
+        if (!this._date) {
           var tmp = new Date()
           this._date = UTCDate(tmp.getFullYear(),
                               tmp.getMonth(),
@@ -303,8 +306,6 @@
                               tmp.getMinutes(),
                               tmp.getSeconds(),
                               tmp.getMilliseconds())
-        } else {
-          this._date = this.parseDate(dateStr);
         }
       }
       this.viewDate = UTCDate(this._date.getUTCFullYear(), this._date.getUTCMonth(), 1, 0, 0, 0, 0);


### PR DESCRIPTION
The latest version of jQuery wraps appended &lt;tr&gt; elements in a &lt;tbody&gt;.
This prevents extra &lt;tbody&gt; tags which break the layout.
