### PR TITLE
with correct form input input prepend / append is on wrong div

### DIFF
--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -54,7 +54,7 @@
       this.pickTime = options.pickTime;
       this.isInput = this.$element.is('input');
       this.component = false;
-      if (this.$element.is('.input-append') || this.$element.is('.input-prepend'))
+      if (this.$element.find('.input-append') || this.$element.find('.input-prepend'))
           this.component = this.$element.find('.add-on');
       this.format = options.format;
       if (!this.format) {


### PR DESCRIPTION
class should not be on control-group

e.g.

``` html
<script type="text/javascript">
    $(document).ready(function() {
        $('#div_id_til').datetimepicker({
            format: 'yyyy-MM-dd hh:mm',
            language: 'nb-NO'
        });
    });
</script>
```

This breaks the layout:

``` html
<div id="div_id_til" class="control-group input-append">
    <label for="id_til" class="control-label required-field">Til</label>
    <div class="controls">
            <input name="til" type="text" id="id_til" value="2013-04-10 23:59" />
            <span class="add-on">
                <i data-time-icon="icon-time" data-date-icon="icon-calendar"></i>
            </span>
            <p class="help-block">Når arrangementet slutter</p>
    </div>
</div>
```

This breaks the js:

``` html
<div id="div_id_til" class="control-group">
    <label for="id_til" class="control-label required-field">Til</label>
    <div class="controls">
        <div class="input-append">
            <input name="til" type="text" id="id_til" value="2013-04-10 23:59" />
            <span class="add-on">
                <i data-time-icon="icon-time" data-date-icon="icon-calendar"></i>
            </span>
            <p class="help-block">Når arrangementet slutter</p>
        </div>
    </div>
</div>
```

This pull fixes the problem with the js
