### PR TITLE
Support for set the orientation of the picker

### DIFF
--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -263,7 +263,16 @@
       var position = 'absolute';
       var offset = this.component ? this.component.offset() : this.$element.offset();
       offset.top = offset.top + this.height;
-
+      
+      if ( this.options.width != undefined ) {
+        this.widget.width( this.options.width );
+      }
+      
+      if ( this.options.orientation == 'left' ) {
+        this.widget.addClass( 'left-oriented' );
+        offset.left   = offset.left - this.widget.width() + 20;
+      }
+      
       if (this._isInFixed()) {
         var $window = $(window);
         position = 'fixed';

--- a/src/less/bootstrap-datetimepicker.less
+++ b/src/less/bootstrap-datetimepicker.less
@@ -158,3 +158,13 @@
     }
   }
 }
+.bootstrap-datetimepicker-widget.left-oriented {
+    &:before {
+        left: auto;
+        right: 6px;
+    }
+    &:after {
+        left: auto;
+        right: 7px;
+    }
+}


### PR DESCRIPTION
- Added support to set the picker display orientation as an attribute, allow the user
  to set if the picker should be rendered to the left or to the right of the input field.
- Added a "width" attribute to set the width for the picker element.
