### PR TITLE
Fix for Format Date 'yy' issue where getYear Depreciated

### DIFF
--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -829,6 +829,9 @@
         } else if (property === 'Period12') {
           if (d.getUTCHours() >= 12) return 'PM';
           else return 'AM';
+		} else if (property === 'UTCYear') {
+          rv = d.getUTCFullYear();
+          rv = rv.toString().substr(2);   
         } else {
           methodName = 'get' + property;
           rv = d[methodName]();


### PR DESCRIPTION
getYear() deprecated. Use the getFullYear() method instead
