### PR TITLE
1970-01-01 00:00:00 can't be entered manually

### DIFF
--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -181,7 +181,7 @@
     },
 
     setValue: function(newDate) {
-      if (!newDate) {
+      if (newDate === null) {
         this._unset = true;
       } else {
         this._unset = false;


### PR DESCRIPTION
If you enter the date 1970-01-01 and time 00:00:00 into the input field and then move the focus away from the input field the field gets emptied. This only happens when you type that date and time, not when you use the datetimepicker itself. 

The bug is caused by function setValue(newDate) when the parameter newDate equals 0 (the integer representation of aforementioned date).
