### PR TITLE
Update the hide method to fix scroll

### DIFF
--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -158,7 +158,7 @@
       this.showMode();
       this.set();
       this.$element.trigger({
-        type: 'hide',
+        type: 'hidden',
         date: this._date
       });
       this._detachDatePickerGlobalEvents();


### PR DESCRIPTION
The datetime modal currently triggers 'hide', while the modal binding is expecting 'hidden.bs.modal'.
This causes the 'hidden' event to not get triggered, meaning that body scroll never gets re-enabled.
