### PR TITLE
when using as only timepicker 00:00 is considered as invalid

### DIFF
--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -181,7 +181,7 @@
     },
 
     setValue: function(newDate) {
-      if (!newDate) {
+      if (newDate===null || newDate===undefined) {
         this._unset = true;
       } else {
         this._unset = false;


### PR DESCRIPTION
because the timestamp is then 0 and if(!0) return true
but 0 is valid
