### PR TITLE
Added semicolon at the end of SIAF

### DIFF
--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -1301,4 +1301,4 @@
   }
 
 
-})(window.jQuery)
+})(window.jQuery);


### PR DESCRIPTION
We are concatenating library scripts into one file and without a `;` at the end there is a conflict with another library:

``` js
    // boostrap-datetimepicker code
})(window.jQuery)

/**
 * Comment
 */(function(factory){
    // next library code
```

```
Uncaught TypeError: (intermediate value)(intermediate value)(intermediate value)(intermediate value)(intermediate value)(intermediate value)(intermediate value)(intermediate value)(intermediate value)(intermediate value)(intermediate value)(intermediate value)(intermediate value)(intermediate value)(intermediate value)(intermediate value)(intermediate value)(intermediate value)(intermediate value)(intermediate value)(intermediate value)(...) is not a function(anonymous function) @ script.js:99
```

See [explanation at SO](http://stackoverflow.com/questions/20307462/js-cant-combine-lib-files)
